### PR TITLE
pref: 规范模型调用问题，修改UpdateTeamReq的Remark参数json描述

### DIFF
--- a/api/co_v1/company.go
+++ b/api/co_v1/company.go
@@ -3,7 +3,6 @@ package co_v1
 import (
 	"github.com/SupenBysz/gf-admin-community/sys_model"
 	"github.com/SupenBysz/gf-admin-company-modules/co_model"
-	"github.com/SupenBysz/gf-admin-company-modules/co_model/co_entity"
 	"github.com/gogf/gf/v2/frame/g"
 )
 
@@ -31,5 +30,3 @@ type UpdateCompanyReq struct {
 	g.Meta `method:"post" summary:"更新组织单位|信息" tags:"组织单位"`
 	co_model.Company
 }
-
-type CompanyRes co_entity.Company

--- a/api/co_v1/employee.go
+++ b/api/co_v1/employee.go
@@ -3,7 +3,6 @@ package co_v1
 import (
 	"github.com/SupenBysz/gf-admin-community/sys_model"
 	"github.com/SupenBysz/gf-admin-company-modules/co_model"
-	"github.com/SupenBysz/gf-admin-company-modules/co_model/co_entity"
 	"github.com/gogf/gf/v2/frame/g"
 )
 
@@ -61,5 +60,3 @@ type GetEmployeeDetailByIdReq struct {
 	g.Meta `method:"post" summary:"获取员工详情|信息" tags:"员工"`
 	Id     int64 `json:"id" v:"required#ID校验失败" dc:"员工ID"`
 }
-
-type EmployeeRes co_entity.CompanyEmployee

--- a/api/co_v1/team.go
+++ b/api/co_v1/team.go
@@ -3,7 +3,6 @@ package co_v1
 import (
 	"github.com/SupenBysz/gf-admin-community/sys_model"
 	"github.com/SupenBysz/gf-admin-company-modules/co_model"
-	"github.com/SupenBysz/gf-admin-company-modules/co_model/co_entity"
 	"github.com/gogf/gf/v2/frame/g"
 )
 
@@ -33,7 +32,7 @@ type UpdateTeamReq struct {
 	g.Meta `method:"post" summary:"更新团队或小组|信息" tags:"团队&小组"`
 	Id     int64  `json:"id" v:"required#团队ID校验失败" dc:"团队或小组ID"`
 	Name   string `json:"name" v:"required#名称不能为空" dc:"名称"`
-	Remark string `json:"name" dc:"备注"`
+	Remark string `json:"remark" dc:"备注"`
 }
 
 type DeleteTeamReq struct {
@@ -69,5 +68,3 @@ type SetTeamCaptainReq struct {
 	Id         int64 `json:"id" v:"required#团队ID校验失败" dc:"团队或小组ID"`
 	EmployeeId int64 `json:"employeeId" v:"required#团队队长ID校验失败" dc:"团队队长ID"`
 }
-
-type TeamRes co_entity.CompanyTeam

--- a/co_controller/company.go
+++ b/co_controller/company.go
@@ -23,8 +23,8 @@ var Company = func(modules co_interface.IModules) *cCompany[co_interface.IModule
 }
 
 // GetCompanyById 通过ID获取公司信息
-func (c *cCompany[T]) GetCompanyById(ctx context.Context, req *co_v1.GetCompanyByIdReq) (res *co_v1.CompanyRes, err error) {
-	return funs.ProxyFunc[*co_v1.CompanyRes](ctx,
+func (c *cCompany[T]) GetCompanyById(ctx context.Context, req *co_v1.GetCompanyByIdReq) (res *co_model.CompanyRes, err error) {
+	return funs.ProxyFunc[*co_model.CompanyRes](ctx,
 		func(ctx context.Context) (*co_entity.Company, error) {
 			return c.modules.Company().GetCompanyById(ctx, req.Id)
 		},
@@ -60,8 +60,8 @@ func (c *cCompany[T]) QueryCompanyList(ctx context.Context, req *co_v1.QueryComp
 }
 
 // CreateCompany 创建公司信息
-func (c *cCompany[T]) CreateCompany(ctx context.Context, req *co_v1.CreateCompanyReq) (*co_v1.CompanyRes, error) {
-	return funs.ProxyFunc1[*co_v1.CompanyRes](
+func (c *cCompany[T]) CreateCompany(ctx context.Context, req *co_v1.CreateCompanyReq) (*co_model.CompanyRes, error) {
+	return funs.ProxyFunc1[*co_model.CompanyRes](
 		ctx, &req.Company,
 		c.modules.Company().CreateCompany, nil,
 		co_enum.Company.PermissionType(c.modules).Update,
@@ -69,8 +69,8 @@ func (c *cCompany[T]) CreateCompany(ctx context.Context, req *co_v1.CreateCompan
 }
 
 // UpdateCompany 更新公司信息
-func (c *cCompany[T]) UpdateCompany(ctx context.Context, req *co_v1.UpdateCompanyReq) (*co_v1.CompanyRes, error) {
-	return funs.ProxyFunc1[*co_v1.CompanyRes](
+func (c *cCompany[T]) UpdateCompany(ctx context.Context, req *co_v1.UpdateCompanyReq) (*co_model.CompanyRes, error) {
+	return funs.ProxyFunc1[*co_model.CompanyRes](
 		ctx, &req.Company,
 		c.modules.Company().UpdateCompany, nil,
 		co_enum.Company.PermissionType(c.modules).Update,

--- a/co_controller/employee.go
+++ b/co_controller/employee.go
@@ -21,8 +21,8 @@ var Employee = func(modules co_interface.IModules) *cEmployee[co_interface.IModu
 	}
 }
 
-func (c *cEmployee[T]) GetEmployeeById(ctx context.Context, req *co_v1.GetEmployeeByIdReq) (*co_v1.EmployeeRes, error) {
-	return funs.ProxyFunc1[*co_v1.EmployeeRes](
+func (c *cEmployee[T]) GetEmployeeById(ctx context.Context, req *co_v1.GetEmployeeByIdReq) (*co_model.EmployeeRes, error) {
+	return funs.ProxyFunc1[*co_model.EmployeeRes](
 		ctx, req.Id,
 		c.modules.Employee().GetEmployeeById, nil,
 		co_enum.Employee.PermissionType(c.modules).ViewDetail,
@@ -30,8 +30,8 @@ func (c *cEmployee[T]) GetEmployeeById(ctx context.Context, req *co_v1.GetEmploy
 }
 
 // GetEmployeeDetailById 获取员工详情信息
-func (c *cEmployee[T]) GetEmployeeDetailById(ctx context.Context, req *co_v1.GetEmployeeDetailByIdReq) (res *co_v1.EmployeeRes, err error) {
-	return funs.ProxyFunc1[*co_v1.EmployeeRes](
+func (c *cEmployee[T]) GetEmployeeDetailById(ctx context.Context, req *co_v1.GetEmployeeDetailByIdReq) (res *co_model.EmployeeRes, err error) {
+	return funs.ProxyFunc1[*co_model.EmployeeRes](
 		ctx, req.Id,
 		c.modules.Employee().GetEmployeeDetailById, nil,
 		co_enum.Employee.PermissionType(c.modules).MoreDetail,
@@ -75,8 +75,8 @@ func (c *cEmployee[T]) QueryEmployeeList(ctx context.Context, req *co_v1.QueryEm
 }
 
 // CreateEmployee 创建员工信息
-func (c *cEmployee[T]) CreateEmployee(ctx context.Context, req *co_v1.CreateEmployeeReq) (*co_v1.EmployeeRes, error) {
-	return funs.ProxyFunc1[*co_v1.EmployeeRes](
+func (c *cEmployee[T]) CreateEmployee(ctx context.Context, req *co_v1.CreateEmployeeReq) (*co_model.EmployeeRes, error) {
+	return funs.ProxyFunc1[*co_model.EmployeeRes](
 		ctx, &req.Employee,
 		c.modules.Employee().CreateEmployee, nil,
 		co_enum.Employee.PermissionType(c.modules).Create,
@@ -84,8 +84,8 @@ func (c *cEmployee[T]) CreateEmployee(ctx context.Context, req *co_v1.CreateEmpl
 }
 
 // UpdateEmployee 更新员工信息
-func (c *cEmployee[T]) UpdateEmployee(ctx context.Context, req *co_v1.UpdateEmployeeReq) (*co_v1.EmployeeRes, error) {
-	return funs.ProxyFunc1[*co_v1.EmployeeRes](
+func (c *cEmployee[T]) UpdateEmployee(ctx context.Context, req *co_v1.UpdateEmployeeReq) (*co_model.EmployeeRes, error) {
+	return funs.ProxyFunc1[*co_model.EmployeeRes](
 		ctx, &req.Employee,
 		c.modules.Employee().UpdateEmployee, nil,
 		co_enum.Employee.PermissionType(c.modules).Update,

--- a/co_controller/team.go
+++ b/co_controller/team.go
@@ -21,8 +21,8 @@ var Team = func(modules co_interface.IModules) *cTeam[co_interface.IModules] {
 	}
 }
 
-func (c *cTeam[T]) GetTeamById(ctx context.Context, req *co_v1.GetTeamByIdReq) (*co_v1.TeamRes, error) {
-	return funs.ProxyFunc1[*co_v1.TeamRes](
+func (c *cTeam[T]) GetTeamById(ctx context.Context, req *co_v1.GetTeamByIdReq) (*co_model.TeamRes, error) {
+	return funs.ProxyFunc1[*co_model.TeamRes](
 		ctx, req.Id,
 		c.modules.Team().GetTeamById, nil,
 		co_enum.Team.PermissionType(c.modules).ViewDetail,
@@ -52,8 +52,8 @@ func (c *cTeam[T]) QueryTeamList(ctx context.Context, req *co_v1.QueryTeamListRe
 	)
 }
 
-func (c *cTeam[T]) CreateTeam(ctx context.Context, req *co_v1.CreateTeamReq) (*co_v1.TeamRes, error) {
-	return funs.ProxyFunc1[*co_v1.TeamRes](
+func (c *cTeam[T]) CreateTeam(ctx context.Context, req *co_v1.CreateTeamReq) (*co_model.TeamRes, error) {
+	return funs.ProxyFunc1[*co_model.TeamRes](
 		ctx, &req.Team,
 		c.modules.Team().CreateTeam,
 		nil,
@@ -61,8 +61,8 @@ func (c *cTeam[T]) CreateTeam(ctx context.Context, req *co_v1.CreateTeamReq) (*c
 	)
 }
 
-func (c *cTeam[T]) UpdateTeam(ctx context.Context, req *co_v1.UpdateTeamReq) (*co_v1.TeamRes, error) {
-	return funs.ProxyFunc3[*co_v1.TeamRes](ctx,
+func (c *cTeam[T]) UpdateTeam(ctx context.Context, req *co_v1.UpdateTeamReq) (*co_model.TeamRes, error) {
+	return funs.ProxyFunc3[*co_model.TeamRes](ctx,
 		req.Id, req.Name, req.Remark,
 		c.modules.Team().UpdateTeam, nil,
 		co_enum.Team.PermissionType(c.modules).Update,

--- a/co_model/company.go
+++ b/co_model/company.go
@@ -13,4 +13,6 @@ type Company struct {
 	Remark        string `json:"remark"         description:"备注"`
 }
 
+type CompanyRes co_entity.Company
+
 type CompanyListRes sys_model.CollectRes[*co_entity.Company]

--- a/co_model/employee.go
+++ b/co_model/employee.go
@@ -16,4 +16,6 @@ type Employee struct {
 	HiredAt *gtime.Time `json:"hiredAt"      v:"date-format:Y-m-d#入职日期" description:"入职日期"`
 }
 
+type EmployeeRes co_entity.CompanyEmployee
+
 type EmployeeListRes sys_model.CollectRes[*co_entity.CompanyEmployee]

--- a/co_model/team.go
+++ b/co_model/team.go
@@ -13,6 +13,6 @@ type Team struct {
 	ParentId          int64  `json:"parentId" description:"团队或小组父级ID"`
 	Remark            string `json:"remark"            description:"备注"`
 }
-
+type TeamRes co_entity.CompanyTeam
 type TeamListRes sys_model.CollectRes[*co_entity.CompanyTeam]
 type TeamMemberListRes sys_model.CollectRes[*co_entity.CompanyTeamMember]

--- a/go.mod
+++ b/go.mod
@@ -45,4 +45,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-replace github.com/SupenBysz/gf-admin-community => E:\CodeSpace.localized\kysionProject\kysion\gf-admin-community
+// replace github.com/SupenBysz/gf-admin-community => E:\CodeSpace.localized\kysionProject\kysion\gf-admin-community

--- a/go.mod
+++ b/go.mod
@@ -45,4 +45,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-// replace github.com/SupenBysz/gf-admin-community => E:\CodeSpace.localized\kysionProject\kysion\gf-admin-community

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I
 github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible h1:1G1pk05UrOh0NlF1oeaaix1x8XzrfjIDK47TY0Zehcw=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
+github.com/SupenBysz/gf-admin-community v0.2.73 h1:MX3h4Fnmcl7aYpE0gG4d7liIFUqHJxak6lYKvbjUGMU=
+github.com/SupenBysz/gf-admin-community v0.2.73/go.mod h1:csLVkT17Sj5AO+9eZpCpNTg1f0CnsR4TA16JcObFVMA=
 github.com/casbin/casbin/v2 v2.60.0 h1:ZmC0/t4wolfEsDpDxTEsu2z6dfbMNpc11F52ceLs2Eo=
 github.com/casbin/casbin/v2 v2.60.0/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=


### PR DESCRIPTION
 包引用问题：
-  login逻辑里面不要用api的包

- login逻辑里是常规类型不要包装

- 容易跨项目引起交叉引用，到时编译不过都查不到哪里问题，交叉引用问题导致的编译不过排查很费劲的。

- login参数用 model，entity 包

- entity不能满足的在model包进行封装或取别名

login层
- logic服务层一般返回类型包为entity或model
- 不要在 服务层使用接口api包中定义的类型。例如 v1 包/api_v1

api层：
- do，只在service使用，entity 在model起别名后给api用。
- 不要直接在api包写entity

controller层：
- controler也不要出现entity，
- controller 可以用service，api，model这3个包下的成员或方法