### PR TITLE
fix: 更新团队信息后返回团队信息数据传递id更换

### DIFF
--- a/internal/logic/company/company_team.go
+++ b/internal/logic/company/company_team.go
@@ -181,7 +181,7 @@ func (s *sTeam) UpdateTeam(ctx context.Context, id int64, name string, remark st
 		return nil, sys_service.SysLogs().ErrorSimple(ctx, err, "保存团队信息失败", co_dao.CompanyTeam.Table())
 	}
 
-	return s.GetTeamById(ctx, data.Id.(int64))
+	return s.GetTeamById(ctx, id)
 }
 
 // GetTeamMemberList 获取团队成员|列表


### PR DESCRIPTION
- data的Id是空的
- 正确的应该是传递进来的id