### PR TITLE
pref: 优化员工数据脱敏逻辑

### DIFF
--- a/internal/logic/company/company_employee.go
+++ b/internal/logic/company/company_employee.go
@@ -378,6 +378,9 @@ func (s *sEmployee) GetEmployeeDetailById(ctx context.Context, id int64) (*co_en
 
 // Masker 员工信息脱敏
 func (s *sEmployee) masker(employee *co_entity.CompanyEmployee) *co_entity.CompanyEmployee {
+	if employee == nil {
+		return nil
+	}
 	employee.Mobile = masker.MaskString(employee.Mobile, masker.MaskPhone)
 	employee.LastActiveIp = masker.MaskString(employee.LastActiveIp, masker.MaskIPv4)
 	return employee


### PR DESCRIPTION
-假如员工数据为空，直接不调用masker脱敏方法，减少资源浪费