### PR TITLE
fix: 修复设置员工团队方法逻辑

### DIFF
--- a/internal/logic/company/company_employee.go
+++ b/internal/logic/company/company_employee.go
@@ -350,7 +350,7 @@ func (s *sEmployee) DeleteEmployee(ctx context.Context, id int64) (bool, error) 
 func (s *sEmployee) setEmployeeTeam(ctx context.Context, employeeId int64) (bool, error) {
 	// 直接删除属于员工的团队成员记录
 	isSuccess, err := s.modules.Team().DeleteTeamMemberByEmployee(ctx, employeeId)
-	if err != nil || isSuccess == false {
+	if err != nil && isSuccess == false {
 		return false, sys_service.SysLogs().ErrorSimple(ctx, err, s.modules.T(ctx, "error_Team_DeleteMember_Failed"), s.dao.Employee.Table())
 	}
 


### PR DESCRIPTION
- 当员工没有团队的时候，那么虽然是删除失败了，但是err确实为空，所以需要&&判断