### PR TITLE
pref: 优化员工逻辑

### DIFF
--- a/internal/logic/company/company_employee.go
+++ b/internal/logic/company/company_employee.go
@@ -459,7 +459,7 @@ func (s *sEmployee) GetEmployeeDetailById(ctx context.Context, id int64) (*co_en
 func (s *sEmployee) GetEmployeeListByRoleId(ctx context.Context, roleId int64) (*co_model.EmployeeListRes, error) {
 	sessionUser := sys_service.SysSession().Get(ctx).JwtClaimsUser
 
-	userIds, err := sys_service.SysRole().GetRoleUserIds(ctx, roleId, sessionUser.UnionMainId)
+	userIds, err := sys_service.SysRole().GetRoleMemberIds(ctx, roleId, sessionUser.UnionMainId)
 	if err != nil {
 		return &co_model.EmployeeListRes{
 			PaginationRes: sys_model.PaginationRes{


### PR DESCRIPTION
- 1.保存员工信息的时候去除多余判断
- 2.更新员工信息的时候，UnionMianId不能更新，强制设置nil
- 3.创建员工信息的是偶UnionMainId 设置为当前登录用户的UnionMainId
- 4.注释优化 // 