### PR TITLE
fix: 创建员工主体id不应该从login层获取传入

### DIFF
--- a/co_controller/internal/employee.go
+++ b/co_controller/internal/employee.go
@@ -95,7 +95,7 @@ func (c *EmployeeController) UpdateEmployee(ctx context.Context, req *co_company
 	return funs.CheckPermission(ctx,
 		func() (*co_model.EmployeeRes, error) {
 			ret, err := c.modules.Employee().UpdateEmployee(ctx, &req.Employee)
-			return (*co_model.EmployeeRes)(ret), err
+			return ret, err
 		},
 		co_enum.Employee.PermissionType(c.modules).Update,
 	)

--- a/co_controller/internal/employee.go
+++ b/co_controller/internal/employee.go
@@ -79,10 +79,12 @@ func (c *EmployeeController) QueryEmployeeList(ctx context.Context, req *co_comp
 
 // CreateEmployee 创建员工信息
 func (c *EmployeeController) CreateEmployee(ctx context.Context, req *co_company_api.CreateEmployeeReq) (*co_model.EmployeeRes, error) {
+	req.UnionMainId = sys_service.SysSession().Get(ctx).JwtClaimsUser.UnionMainId
+
 	return funs.CheckPermission(ctx,
 		func() (*co_model.EmployeeRes, error) {
 			ret, err := c.modules.Employee().CreateEmployee(ctx, &req.Employee)
-			return (*co_model.EmployeeRes)(ret), err
+			return ret, err
 		},
 		co_enum.Employee.PermissionType(c.modules).Create,
 	)

--- a/internal/logic/company/company_employee.go
+++ b/internal/logic/company/company_employee.go
@@ -262,7 +262,6 @@ func (s *sEmployee) QueryEmployeeList(ctx context.Context, search *sys_model.Sea
 // CreateEmployee 创建员工信息
 func (s *sEmployee) CreateEmployee(ctx context.Context, info *co_model.Employee) (*co_model.EmployeeRes, error) {
 	info.Id = 0
-	info.UnionMainId = sys_service.SysSession().Get(ctx).JwtClaimsUser.UnionMainId
 
 	return s.saveEmployee(ctx, info)
 }


### PR DESCRIPTION
- 因为创建公司的时候，是超级管理员去创建的，但是假如要创建默认的员工，是直接调用login层的方法的
- UnionMainId直接从login获取，那么创建公司的时候公司管理员的unionMainId就变成了0