### PR TITLE
pref: 优化部分接口的unionMainId的获取传递

### DIFF
--- a/co_controller/internal/employee.go
+++ b/co_controller/internal/employee.go
@@ -47,11 +47,9 @@ func (c *EmployeeController) GetEmployeeDetailById(ctx context.Context, req *co_
 
 // HasEmployeeByName 员工名称是否存在
 func (c *EmployeeController) HasEmployeeByName(ctx context.Context, req *co_company_api.HasEmployeeByNameReq) (api_v1.BoolRes, error) {
-	unionMainId := sys_service.SysSession().Get(ctx).JwtClaimsUser.UnionMainId
-
 	return funs.CheckPermission(ctx,
 		func() (api_v1.BoolRes, error) {
-			return c.modules.Employee().HasEmployeeByName(ctx, req.Name, unionMainId, req.ExcludeId) == true, nil
+			return c.modules.Employee().HasEmployeeByName(ctx, req.Name, req.ExcludeId) == true, nil
 		},
 	)
 }

--- a/co_controller/internal/team.go
+++ b/co_controller/internal/team.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"context"
 	"github.com/SupenBysz/gf-admin-community/api_v1"
-	"github.com/SupenBysz/gf-admin-community/sys_service"
 	"github.com/SupenBysz/gf-admin-community/utility/funs"
 	"github.com/SupenBysz/gf-admin-company-modules/api/co_company_api"
 	"github.com/SupenBysz/gf-admin-company-modules/co_interface"
@@ -37,11 +36,9 @@ func (c *TeamController[T]) GetTeamById(ctx context.Context, req *co_company_api
 	)
 }
 func (c *TeamController[T]) HasTeamByName(ctx context.Context, req *co_company_api.HasTeamByNameReq) (api_v1.BoolRes, error) {
-	unionMainId := sys_service.SysSession().Get(ctx).JwtClaimsUser.UnionMainId
-
 	return funs.CheckPermission(ctx,
 		func() (api_v1.BoolRes, error) {
-			return c.modules.Team().HasTeamByName(ctx, req.Name, unionMainId, req.ExcludeId) == true, nil
+			return c.modules.Team().HasTeamByName(ctx, req.Name, req.ExcludeId) == true, nil
 		},
 	)
 }

--- a/co_interface/service_interface.go
+++ b/co_interface/service_interface.go
@@ -30,7 +30,7 @@ type (
 	IEmployee interface {
 		GetEmployeeById(ctx context.Context, id int64) (*co_model.EmployeeRes, error)
 		GetEmployeeByName(ctx context.Context, name string) (*co_model.EmployeeRes, error)
-		HasEmployeeByName(ctx context.Context, name string, unionMainId int64, excludeIds ...int64) bool
+		HasEmployeeByName(ctx context.Context, name string, excludeIds ...int64) bool
 		HasEmployeeByNo(ctx context.Context, no string, unionMainId int64, excludeIds ...int64) bool
 		GetEmployeeBySession(ctx context.Context) (*co_model.EmployeeRes, error)
 		QueryEmployeeList(ctx context.Context, search *sys_model.SearchParams) (*co_model.EmployeeListRes, error)

--- a/co_interface/service_interface.go
+++ b/co_interface/service_interface.go
@@ -45,7 +45,7 @@ type (
 	ITeam interface {
 		GetTeamById(ctx context.Context, id int64) (*co_model.TeamRes, error)
 		GetTeamByName(ctx context.Context, name string) (*co_model.TeamRes, error)
-		HasTeamByName(ctx context.Context, name string, unionMainId int64, excludeIds ...int64) bool
+		HasTeamByName(ctx context.Context, name string, excludeIds ...int64) bool
 		QueryTeamList(ctx context.Context, search *sys_model.SearchParams) (*co_model.TeamListRes, error)
 		QueryTeamMemberList(ctx context.Context, search *sys_model.SearchParams) (*co_model.TeamMemberListRes, error)
 		CreateTeam(ctx context.Context, info *co_model.Team) (*co_model.TeamRes, error)

--- a/internal/logic/company/company_employee.go
+++ b/internal/logic/company/company_employee.go
@@ -147,7 +147,9 @@ func (s *sEmployee) GetEmployeeByName(ctx context.Context, name string) (*co_mod
 }
 
 // HasEmployeeByName 员工名称是否存在
-func (s *sEmployee) HasEmployeeByName(ctx context.Context, name string, unionMainId int64, excludeIds ...int64) bool {
+func (s *sEmployee) HasEmployeeByName(ctx context.Context, name string, excludeIds ...int64) bool {
+	unionMainId := sys_service.SysSession().Get(ctx).JwtClaimsUser.UnionMainId
+
 	model := s.dao.Employee.Ctx(ctx).Hook(daoctl.CacheHookHandler).Where(co_do.CompanyEmployee{
 		Name:        name,
 		UnionMainId: unionMainId,

--- a/internal/logic/company/company_team.go
+++ b/internal/logic/company/company_team.go
@@ -68,7 +68,9 @@ func (s *sTeam) GetTeamByName(ctx context.Context, name string) (*co_model.TeamR
 }
 
 // HasTeamByName 团队名称是否存在
-func (s *sTeam) HasTeamByName(ctx context.Context, name string, unionMainId int64, excludeIds ...int64) bool {
+func (s *sTeam) HasTeamByName(ctx context.Context, name string, excludeIds ...int64) bool {
+	unionMainId := sys_service.SysSession().Get(ctx).JwtClaimsUser.UnionMainId
+
 	model := s.dao.Team.Ctx(ctx).Hook(daoctl.CacheHookHandler).Where(co_do.CompanyTeam{
 		Name:        name,
 		UnionMainId: unionMainId,
@@ -154,7 +156,7 @@ func (s *sTeam) CreateTeam(ctx context.Context, info *co_model.Team) (*co_model.
 	sessionUser := sys_service.SysSession().Get(ctx).JwtClaimsUser
 
 	// 判断团队名称是否存在
-	if s.HasTeamByName(ctx, info.Name, sessionUser.UnionMainId) == true {
+	if s.HasTeamByName(ctx, info.Name) == true {
 		return nil, sys_service.SysLogs().ErrorSimple(ctx, nil, s.modules.T(ctx, "error_Team_TeamNameExist"), s.dao.Team.Table())
 	}
 
@@ -231,9 +233,8 @@ func (s *sTeam) CreateTeam(ctx context.Context, info *co_model.Team) (*co_model.
 
 // UpdateTeam 更新团队或小组|信息
 func (s *sTeam) UpdateTeam(ctx context.Context, id int64, name string, remark string) (*co_model.TeamRes, error) {
-	sessionUser := sys_service.SysSession().Get(ctx).JwtClaimsUser
 
-	if s.HasTeamByName(ctx, name, sessionUser.UnionMainId, id) == true {
+	if s.HasTeamByName(ctx, name, id) == true {
 		return nil, sys_service.SysLogs().ErrorSimple(ctx, nil, s.modules.T(ctx, "error_Team_TeamNameExist"), s.dao.Team.Table())
 	}
 


### PR DESCRIPTION
如下接口unionMainId需从login层获取：
- 判断公司名称是否存在 (这个不需要unionMainId作为条件)
- 判断员工名称是够存在
- 判断员工工号是否存在
- 判断团队|小组名称是否存在
