### PR TITLE
fix: 修复查询员工没有进行跨主体判断Bug

### DIFF
--- a/internal/logic/company/company_employee.go
+++ b/internal/logic/company/company_employee.go
@@ -113,8 +113,11 @@ func (s *sEmployee) jwtHookFunc(ctx context.Context, claims *sys_model.JwtCustom
 
 // GetEmployeeById 根据ID获取员工信息
 func (s *sEmployee) GetEmployeeById(ctx context.Context, id int64) (*co_model.EmployeeRes, error) {
+	sessionUser := sys_service.SysSession().Get(ctx).JwtClaimsUser
+
 	data, err := daoctl.GetByIdWithError[co_model.EmployeeRes](
-		s.dao.Employee.Ctx(ctx), id,
+		s.dao.Employee.Ctx(ctx),
+		id,
 	)
 
 	if err != nil {
@@ -124,6 +127,12 @@ func (s *sEmployee) GetEmployeeById(ctx context.Context, id int64) (*co_model.Em
 		}
 		return nil, sys_service.SysLogs().ErrorSimple(ctx, err, message, s.dao.Employee.Table())
 	}
+
+	// 跨主体禁止查看员工信息，下级公司可查看上级公司员工信息
+	if err == sql.ErrNoRows || data != nil && data.UnionMainId != sessionUser.UnionMainId && data.UnionMainId != sessionUser.ParentId {
+		return nil, sys_service.SysLogs().ErrorSimple(ctx, err, s.modules.T(ctx, "{#EmployeeName} {#error_Data_NotFound}"), s.dao.Employee.Table())
+	}
+
 	return s.masker(s.makeMore(ctx, data)), nil
 }
 


### PR DESCRIPTION
- 修改前：允许跨主体查询员工
- 修改后：不允许跨主体查询员工 注意：禁止跨级查看列表，但是可以查看单个员工