### PR TITLE
fix: 修复创建提现账号状态缺少BUG

### DIFF
--- a/internal/logic/financial/fd_bank_card.go
+++ b/internal/logic/financial/fd_bank_card.go
@@ -55,6 +55,8 @@ func (s *sFdBankCard) CreateBankCard(ctx context.Context, info co_model.BankCard
 
 	// 当前用户创建的就是自己的银行卡账号
 	bankCardInfo.UserId = user.Id
+	// 默认状态正常
+	bankCardInfo.State = 1
 
 	// 添加银行卡
 	_, err = s.dao.FdBankCard.Ctx(ctx).Data(bankCardInfo).Insert()


### PR DESCRIPTION
- 申请提现账号后默认状态就是正常1
-   0禁用