### PR TITLE
fix: 修复模版函数依赖引用

### DIFF
--- a/example/hack/tpls/dao_template.tpl
+++ b/example/hack/tpls/dao_template.tpl
@@ -5,7 +5,7 @@
 package co_dao
 
 import (
-	"github.com/SupenBysz/gf-admin-community/utility/daoctl/dao_interface"
+	"github.com/kysion/base-library/utility/daoctl/dao_interface"
 	"{TplImportPrefix}/internal"
 )
 

--- a/hack/tpls/dao_template.tpl
+++ b/hack/tpls/dao_template.tpl
@@ -5,7 +5,7 @@
 package co_dao
 
 import (
-	"github.com/SupenBysz/gf-admin-community/utility/daoctl/dao_interface"
+	"github.com/kysion/base-library/utility/daoctl/dao_interface"
 	"{TplImportPrefix}/internal"
 )
 


### PR DESCRIPTION
- 适配base-library的更改