### PR TITLE
fix: 修复用户登录Hook，避免引起空指针错误

### DIFF
--- a/internal/logic/company/company_employee.go
+++ b/internal/logic/company/company_employee.go
@@ -72,8 +72,13 @@ func (s *sEmployee) authHookFunc(ctx context.Context, _ sys_enum.AuthActionType,
 		user.Detail.Realname = employee.Name
 	}
 
-	company, _ := s.modules.Company().GetCompanyById(ctx, employee.UnionMainId)
-	if company != nil {
+	company := &co_model.CompanyRes{}
+
+	if employee != nil && employee.UnionMainId != 0 {
+		company, _ = s.modules.Company().GetCompanyById(ctx, employee.UnionMainId)
+	}
+
+	if company.Name != "" {
 		user.Detail.UnionMainName = company.Name
 	}
 


### PR DESCRIPTION
- 应该对员工的主体进行判断，在去获取他的公司，因为像是系统用户这样的，他是没有主体的，但是他也有登录系统的需求
- 不用担心employee.UnionMainId != 0 会引起错误，因为是&&条件，前面不满足，是false了，他就不会执行if后面的逻辑
