### PR TITLE
pref: 将财务服务权限树暴露出来

### DIFF
--- a/co_consts/co_const.go
+++ b/co_consts/co_const.go
@@ -6,4 +6,6 @@ import (
 
 var (
 	PermissionTree []*sys_model.SysPermissionTree
+
+	FinancialPermissionTree []*sys_model.SysPermissionTree
 )

--- a/co_module/modules.go
+++ b/co_module/modules.go
@@ -319,7 +319,7 @@ func NewModules[
 
 	// 权限树追加权限
 	co_consts.PermissionTree = append(co_consts.PermissionTree, boot.InitPermission(response)...)
-	co_consts.FinancialPermissionTree = append(co_consts.FinancialPermissionTree, boot.InitFinancialPermission(module)...)
+	co_consts.FinancialPermissionTree = append(co_consts.FinancialPermissionTree, boot.InitFinancialPermission(response)...)
 
 	return module
 }

--- a/co_module/modules.go
+++ b/co_module/modules.go
@@ -319,6 +319,7 @@ func NewModules[
 
 	// 权限树追加权限
 	co_consts.PermissionTree = append(co_consts.PermissionTree, boot.InitPermission(response)...)
+	co_consts.FinancialPermissionTree = append(co_consts.FinancialPermissionTree, boot.InitFinancialPermission(module)...)
 
 	return module
 }

--- a/internal/logic/company/company_employee.go
+++ b/internal/logic/company/company_employee.go
@@ -171,7 +171,7 @@ func (s *sEmployee[
 
 	if !reflect.ValueOf(employee).IsNil() && employee.Data().UnionMainId != 0 {
 		company, _ := s.modules.Company().GetCompanyById(ctx, employee.Data().UnionMainId)
-		if company != nil {
+		if !reflect.ValueOf(company).IsNil() {
 			user.Detail.UnionMainName = company.Data().Name
 		}
 	}


### PR DESCRIPTION
- 这样业务项目要是不想自己定义权限树，那就可以直接引用骨架的权限树