### PR TITLE
feat: 在员工模型中添加头像字段并更新员工信息逻辑

### DIFF
--- a/co_model/employee.go
+++ b/co_model/employee.go
@@ -33,6 +33,7 @@ type UpdateEmployee struct {
 	OverrideDo  base_interface.DoModel[co_do.CompanyEmployee] `json:"-"`
 	Id          int64                                         `json:"id"           dc:"ID，保持与USERID一致" v:"required#请输入员工ID"`
 	No          *string                                       `json:"no"           v:"max-length:16#工号长度超出限定16字符" dc:"工号"`
+	Avatar      string                                        `json:"avatar"       dc:"头像"`
 	Name        *string                                       `json:"name"         v:"required|max-length:32#姓名不能为空|姓名长度超出限定32字符" dc:"姓名"`
 	Mobile      *string                                       `json:"mobile"       v:"phone#手机号校验失败" dc:"手机号"`
 	State       *int                                          `json:"state"        v:"in:-1,0,1#请选择员工状态" dc:"状态：-1已离职，0待确认，1已入职"`


### PR DESCRIPTION
- 在 UpdateEmployee 结构体中新增 Avatar 字段
- 更新员工信息时，添加头像文件的校验和保存逻辑
- 修改相关查询和更新逻辑以支持头像处理