### PR TITLE
feat: 更新团队相关请求结构体，统一ID校验信息

### DIFF
--- a/api/co_company_api/team.go
+++ b/api/co_company_api/team.go
@@ -6,7 +6,7 @@ import (
 )
 
 type GetTeamByIdReq struct {
-	Id      int64    `json:"id" v:"required#团队ID校验失败" dc:"团队或小组ID"`
+	Id      int64    `json:"id" v:"required#部门|团队|小组ID校验失败" dc:"部门|团队|小组ID"`
 	Include []string `json:"include" dc:"需要附加数据的返回值字段集，如果没有填写，默认不附加数据"`
 }
 
@@ -14,7 +14,7 @@ type HasTeamByNameReq struct {
 	Name        string `json:"name" v:"required#名称不能为空" dc:"名称"`
 	UnionNameId int64  `json:"unionNameId" dc:"关联主体ID"`
 	//ParentId    int64  `json:"parentId" dc:"关联的上级团队ID，没有的话或不限制就不填写"`
-	ExcludeId int64 `json:"excludeId" dc:"要排除的团队ID"`
+	ExcludeId int64 `json:"excludeId" dc:"要排除的部门/团队/小组ID"`
 }
 
 type QueryTeamListReq struct {
@@ -28,15 +28,12 @@ type CreateTeamReq struct {
 }
 
 type UpdateTeamReq struct {
-	Id int64 `json:"id" v:"required#团队ID校验失败" dc:"团队或小组ID"`
-	//Name   string `json:"name" v:"required#名称不能为空" dc:"名称"`
-	Name    string   `json:"name"  dc:"名称"`
-	Remark  string   `json:"remark" dc:"备注"`
+	co_model.Team
 	Include []string `json:"include" dc:"需要附加数据的返回值字段集，如果没有填写，默认不附加数据"`
 }
 
 type DeleteTeamReq struct {
-	Id int64 `json:"id" v:"required#团队ID校验失败" dc:"团队或小组ID"`
+	Id int64 `json:"id" v:"required#部门|团队|小组ID校验失败" dc:"部门|团队|小组ID"`
 }
 type QueryTeamListByEmployeeReq struct {
 	EmployeeId  int64    `json:"employeeId" v:"required#员工ID校验失败" dc:"员工ID"`
@@ -45,32 +42,32 @@ type QueryTeamListByEmployeeReq struct {
 }
 
 type SetTeamMemberReq struct {
-	Id          int64   `json:"id" v:"required#团队ID校验失败" dc:"团队或小组ID"`
+	Id          int64   `json:"id" v:"required#部门|团队|小组ID校验失败" dc:"部门|团队|小组ID"`
 	EmployeeIds []int64 `json:"employeeIds" dc:"团队成员"`
 }
 
 type RemoveTeamMemberReq struct {
-	Id          int64   `json:"id" v:"required#团队ID校验失败" dc:"团队或小组ID"`
+	Id          int64   `json:"id" v:"required#部门|团队|小组ID校验失败" dc:"部门|团队|小组ID"`
 	EmployeeIds []int64 `json:"employeeIds" dc:"团队成员ids"`
 }
 
 type SetTeamOwnerReq struct {
-	Id         int64 `json:"id" v:"required#团队ID校验失败" dc:"团队或小组ID"`
+	Id         int64 `json:"id" v:"required#部门|团队|小组ID校验失败" dc:"部门|团队|小组ID"`
 	EmployeeId int64 `json:"employeeId" v:"required#团队管理者ID校验失败" dc:"团队管理者ID"`
 }
 
 type SetTeamCaptainReq struct {
-	Id         int64 `json:"id" v:"required#团队ID校验失败" dc:"团队或小组ID"`
+	Id         int64 `json:"id" v:"required#部门|团队|小组ID校验失败" dc:"部门|团队|小组ID"`
 	EmployeeId int64 `json:"employeeId" v:"required#团队队长ID校验失败" dc:"团队队长ID"`
 }
 
 type GetEmployeeListByTeamIdReq struct {
-	TeamId  int64    `json:"teamId" v:"required#团队ID校验失败" dc:"团队或小组ID"`
+	TeamId  int64    `json:"teamId" v:"required#部门|团队|小组ID校验失败" dc:"部门|团队|小组ID"`
 	Include []string `json:"include" dc:"需要附加数据的返回值字段集，如果没有填写，默认不附加数据"`
 }
 
 type GetTeamInviteCodeReq struct {
-	TeamId int64 `json:"teamId" v:"required#团队ID校验失败" dc:"团队或小组ID"`
+	TeamId int64 `json:"teamId" v:"required#部门|团队|小组ID校验失败" dc:"部门|团队|小组ID"`
 }
 
 type JoinTeamByInviteCodeReq struct {

--- a/co_controller/internal/team.go
+++ b/co_controller/internal/team.go
@@ -22,15 +22,15 @@ import (
 )
 
 type TeamController[
-	ITCompanyRes co_model.ICompanyRes,
-	ITEmployeeRes co_model.IEmployeeRes,
-	TIRes co_model.ITeamRes,
-	ITFdAccountRes co_model.IFdAccountRes,
-	ITFdAccountBillRes co_model.IFdAccountBillRes,
-	ITFdBankCardRes co_model.IFdBankCardRes,
-	ITFdCurrencyRes co_model.IFdCurrencyRes,
-	ITFdInvoiceRes co_model.IFdInvoiceRes,
-	ITFdInvoiceDetailRes co_model.IFdInvoiceDetailRes,
+ITCompanyRes co_model.ICompanyRes,
+ITEmployeeRes co_model.IEmployeeRes,
+TIRes co_model.ITeamRes,
+ITFdAccountRes co_model.IFdAccountRes,
+ITFdAccountBillRes co_model.IFdAccountBillRes,
+ITFdBankCardRes co_model.IFdBankCardRes,
+ITFdCurrencyRes co_model.IFdCurrencyRes,
+ITFdInvoiceRes co_model.IFdInvoiceRes,
+ITFdInvoiceDetailRes co_model.IFdInvoiceDetailRes,
 ] struct {
 	modules co_interface.IModules[
 		ITCompanyRes,
@@ -50,15 +50,15 @@ type TeamController[
 }
 
 func Team[
-	ITCompanyRes co_model.ICompanyRes,
-	ITEmployeeRes co_model.IEmployeeRes,
-	TIRes co_model.ITeamRes,
-	ITFdAccountRes co_model.IFdAccountRes,
-	ITFdAccountBillRes co_model.IFdAccountBillRes,
-	ITFdBankCardRes co_model.IFdBankCardRes,
-	ITFdCurrencyRes co_model.IFdCurrencyRes,
-	ITFdInvoiceRes co_model.IFdInvoiceRes,
-	ITFdInvoiceDetailRes co_model.IFdInvoiceDetailRes,
+ITCompanyRes co_model.ICompanyRes,
+ITEmployeeRes co_model.IEmployeeRes,
+TIRes co_model.ITeamRes,
+ITFdAccountRes co_model.IFdAccountRes,
+ITFdAccountBillRes co_model.IFdAccountBillRes,
+ITFdBankCardRes co_model.IFdBankCardRes,
+ITFdCurrencyRes co_model.IFdCurrencyRes,
+ITFdInvoiceRes co_model.IFdInvoiceRes,
+ITFdInvoiceDetailRes co_model.IFdInvoiceDetailRes,
 ](modules co_interface.IModules[
 	ITCompanyRes,
 	ITEmployeeRes,
@@ -189,7 +189,7 @@ func (c *TeamController[
 	permission := c.getPermission(ctx, co_permission.Team.PermissionType(c.modules).Update)
 	return funs.CheckPermission(ctx,
 		func() (TIRes, error) {
-			ret, err := c.team.UpdateTeam(c.makeMore(ctx), req.Id, req.Name, req.Remark)
+			ret, err := c.team.UpdateTeam(c.makeMore(ctx), &req.Team)
 			return ret, err
 		},
 		permission,

--- a/co_interface/service_interface.go
+++ b/co_interface/service_interface.go
@@ -80,7 +80,7 @@ type (
 		// CreateTeam 创建团队或小组|信息
 		CreateTeam(ctx context.Context, info *co_model.Team) (TR, error)
 		// UpdateTeam 更新团队或小组|信息
-		UpdateTeam(ctx context.Context, id int64, name string, remark string) (TR, error)
+		UpdateTeam(ctx context.Context, info *co_model.Team) (TR, error)
 		// QueryTeamListByEmployee 根据员工查询团队
 		QueryTeamListByEmployee(ctx context.Context, employeeId int64, unionMainId int64) (*base_model.CollectRes[TR], error)
 		// SetTeamMember 设置团队队员或小组组员

--- a/co_model/team.go
+++ b/co_model/team.go
@@ -1,31 +1,32 @@
 package co_model
 
 import (
+	"reflect"
+
 	"github.com/SupenBysz/gf-admin-community/sys_model"
 	"github.com/SupenBysz/gf-admin-company-modules/base_interface"
 	"github.com/SupenBysz/gf-admin-company-modules/co_model/co_do"
 	"github.com/SupenBysz/gf-admin-company-modules/co_model/co_entity"
 	"github.com/kysion/base-library/utility/kconv"
-	"reflect"
 )
 
 type Team struct {
 	OverrideDo        base_interface.DoModel[co_do.CompanyTeam]       `json:"-"`
 	TeamMemberDo      base_interface.DoModel[co_do.CompanyTeamMember] `json:"-"`
 	Id                int64                                           `json:"id"                dc:"ID"`
-	Name              string                                          `json:"name"              v:"required|max-length:128#名称不能为空|名称长度超128字符出限定范围" dc:"团队名称，公司维度下唯一"`
-	OwnerEmployeeId   int64                                           `json:"ownerEmployeeId"   dc:"团队所有者/业务总监/业务经理/团队队长"`
-	CaptainEmployeeId int64                                           `json:"captainEmployeeId" dc:"团队队长编号/小组组长"`
+	Name              string                                          `json:"name"              v:"required|max-length:128#名称不能为空|名称长度超128字符出限定范围" dc:"部门/团队/小组名称，公司维度下唯一"`
+	OwnerEmployeeId   int64                                           `json:"ownerEmployeeId"   dc:"部门/团队所有者/业务总监/业务经理/团队队长"`
+	CaptainEmployeeId int64                                           `json:"captainEmployeeId" dc:"部门/团队队长编号/小组组长"`
 	ParentId          int64                                           `json:"parentId" dc:"团队或小组父级ID"`
 	Remark            string                                          `json:"remark"            dc:"备注"`
 }
 
 type TeamRes struct {
 	co_entity.CompanyTeam
-	Owner     *EmployeeRes `json:"owner" dc:"团队所有者/业务总监/业务经理/团队队长"`
-	Captain   *EmployeeRes `json:"captain" dc:"团队队长编号/小组组长"`
+	Owner     *EmployeeRes `json:"owner" dc:"部门/团队所有者/业务总监/业务经理/团队队长"`
+	Captain   *EmployeeRes `json:"captain" dc:"部门/团队队长编号/小组组长"`
 	UnionMain *CompanyRes  `json:"unionMain" dc:"关联主体"`
-	Parent    *TeamRes     `json:"parent" dc:"团队或小组父级ID"`
+	Parent    *TeamRes     `json:"parent" dc:"部门/团队/小组父级ID"`
 }
 
 // 这些从配置加载


### PR DESCRIPTION
- 修改多个请求结构体中的ID字段描述，将“团队或小组ID”更新为“部门|团队|小组ID”，以提高描述的准确性和一致性
- 更新团队模型中的名称和备注字段描述，确保与业务逻辑相符
- 调整团队控制器和服务接口，采用新的团队更新逻辑，简化参数传递